### PR TITLE
fix: vista de fechas, aspirantes

### DIFF
--- a/src/app/components/listado-aspirantes/listado_aspirantes/listado_aspirante.component.html
+++ b/src/app/components/listado-aspirantes/listado_aspirantes/listado_aspirante.component.html
@@ -210,7 +210,7 @@
             <th mat-header-cell *matHeaderCellDef>
               {{ "inscripcion.fecha_generacion" | translate }}
             </th>
-            <td mat-cell *matCellDef="let row"> {{ row?.Inscripcion?.FechaCreacion | date:'yyyy-MM-dd' }}</td>
+            <td mat-cell *matCellDef="let row"> {{ row?.Inscripcion?.FechaCreacion ? row.Inscripcion.FechaCreacion.split(' ')[0] : '' }}</td>
             <!-- <td mat-cell *matCellDef="let row"> {{ formatFechaInscripcion(row) }}</td> -->
           </ng-container>
           <ng-container matColumnDef="tipo_de_inscripcion">


### PR DESCRIPTION
Se corrige la vista de fechas en el listado de aspirantes para evitar incompatibilidades con navegadores (ERROR Error: NG02100 en transformación de fechas por pipe personalizado).